### PR TITLE
Specify rspec dependendy ~> 2.9.0

### DIFF
--- a/rspec-nc.gemspec
+++ b/rspec-nc.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/twe4ked/rspec-nc'
 
   gem.add_dependency 'terminal-notifier', '~> 1.4.2'
+  gem.add_dependency 'rspec', '~> 2.9.0'
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
I tried with rspec 2.8.0 and got this error

``` shell
Users/nicolasnardone/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rspec-nc-0.0.3/lib/nc.rb:7:in `dump_summary': undefined method `format_duration' for #<Nc:0x007fd7eb00b840> (NoMethodError)
    from /Users/nicolasnardone/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rspec-core-2.8.0/lib/rspec/core/reporter.rb:98:in `block in notify'
    from /Users/nicolasnardone/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rspec-core-2.8.0/lib/rspec/core/reporter.rb:97:in `each'
    from /Users/nicolasnardone/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rspec-core-2.8.0/lib/rspec/core/reporter.rb:97:in `notify'
    from /Users/nicolasnardone/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rspec-core-2.8.0/lib/rspec/core/reporter.rb:82:in `finish'
    from /Users/nicolasnardone/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rspec-core-2.8.0/lib/rspec/core/reporter.rb:36:in `report'
    from /Users/nicolasnardone/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rspec-core-2.8.0/lib/rspec/core/command_line.rb:25:in `run'
    from /Users/nicolasnardone/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rspec-core-2.8.0/lib/rspec/core/runner.rb:80:in `run_in_process'
    from /Users/nicolasnardone/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rspec-core-2.8.0/lib/rspec/core/runner.rb:66:in `rescue in run'
    from /Users/nicolasnardone/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rspec-core-2.8.0/lib/rspec/core/runner.rb:62:in `run'
    from /Users/nicolasnardone/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rspec-core-2.8.0/lib/rspec/core/runner.rb:10:in `block in autorun'
```

indeed format_duration was added in version 2.9.0 by [this](https://github.com/rspec/rspec-core/commit/76be2a821876db5b766fd276d2cb9f92174903a1) commit.

Thus my pull request to be more specific about the gem requirements.
