### PR TITLE
New notifier for first failure.

### DIFF
--- a/lib/nc_first_fail.rb
+++ b/lib/nc_first_fail.rb
@@ -1,0 +1,14 @@
+require 'nc'
+
+class NcFirstFail < Nc
+  def example_failed(example)
+    if @failed_examples.size == 0
+      say "\u26D4 #{example.metadata[:full_description]}", example.exception
+    end
+    super
+  end
+
+  def dump_summary(duration, example_count, failure_count, pending_count)
+    super if failure_count == 0
+  end
+end

--- a/spec/nc_first_fail_spec.rb
+++ b/spec/nc_first_fail_spec.rb
@@ -1,0 +1,31 @@
+require 'nc_first_fail'
+
+describe NcFirstFail do
+  let(:formatter) { NcFirstFail.new(StringIO.new) }
+  let(:example) { double 'example' }
+  let(:example2) { double 'example2' }
+
+  let(:failure) { "\u26D4" }
+  let(:exception) { 'exception' }
+  let(:description) { 'description' }
+
+  before do
+    example.should_receive(:metadata).any_number_of_times.and_return({:full_description => description})
+    example.should_receive(:exception).any_number_of_times.and_return(exception)
+  end
+
+  it 'notifies the first failure only' do
+    TerminalNotifier.should_receive(:notify).with(exception,
+      :title => "#{failure} #{description}"
+    )
+
+    formatter.example_failed(example)
+    formatter.example_failed(example2)
+  end
+
+  it "doesn't notify in the end if there has been any failures" do
+    TerminalNotifier.should_not_receive(:notify)
+
+    formatter.dump_summary(0.0001, 2, 1, 0)
+  end
+end


### PR DESCRIPTION
It notifies as soon as the first failure happens. If nothing fails, it
notifies in the end.
