### PR TITLE
Avoid crashing TerminalNotifier for MAC OS X (< 10.8)

### DIFF
--- a/lib/nc.rb
+++ b/lib/nc.rb
@@ -25,6 +25,6 @@ class Nc < RSpec::Core::Formatters::BaseTextFormatter
   private
 
   def say(title, body)
-    TerminalNotifier.notify body, :title => title
+    TerminalNotifier.notify body, :title => title if TerminalNotifier.available?
   end
 end


### PR DESCRIPTION
...ot try to notify and cause a crash.