### PR TITLE
update terminal-notifier for yosemite

### DIFF
--- a/rspec-nc.gemspec
+++ b/rspec-nc.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/twe4ked/rspec-nc'
   gem.license = 'MIT'
 
-  gem.add_dependency 'terminal-notifier', '~> 1.4.2'
+  gem.add_dependency 'terminal-notifier', '~> 1.6.1'
   gem.add_dependency 'rspec', '>= 2.9'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Previous versions of terminal-notifier didn't support os x yosemite. I changed the terminal-notifier version according to [this issue](https://github.com/alloy/terminal-notifier/issues/101) and tried a couple of test suites. It seems to work fine in yosemite beta just doing this. 
