### PR TITLE
fix the deprecated formatter interface warning

### DIFF
--- a/lib/nc.rb
+++ b/lib/nc.rb
@@ -2,11 +2,26 @@ require 'rspec/core/formatters/base_text_formatter'
 require 'terminal-notifier'
 
 class Nc < RSpec::Core::Formatters::BaseTextFormatter
-  if RSpec::Core::Formatters.respond_to? :register
-    RSpec::Core::Formatters.register self.class, :example_failed
+
+  def self.rspec_3?
+    RSpec::Core::Version::STRING.split('.').first == "3"
   end
 
-  def dump_summary(duration, example_count, failure_count, pending_count)
+  if rspec_3?
+    RSpec::Core::Formatters.register self, :dump_summary
+  end
+
+  def dump_summary(*args)
+    if self.class.rspec_3?
+      notification = args[0]
+      duration = notification.duration
+      example_count = notification.example_count
+      failure_count = notification.failure_count
+      pending_count = notification.pending_count
+    else
+      duration, example_count, failure_count, pending_count = args
+    end
+
     body = []
     body << "Finished in #{_format_duration duration}"
     body << _summary_line(example_count, failure_count, pending_count)
@@ -22,8 +37,8 @@ class Nc < RSpec::Core::Formatters::BaseTextFormatter
     say title, body.join("\n")
   end
 
-  def dump_pending; end
-  def dump_failures; end
+  def dump_pending(*args); end
+  def dump_failures(*args); end
   def message(message); end
 
   private

--- a/lib/nc_fail.rb
+++ b/lib/nc_fail.rb
@@ -1,6 +1,10 @@
 require 'nc'
 
 class NcFail < Nc
+  if rspec_3?
+    RSpec::Core::Formatters.register self, :example_failed
+  end
+
   def say(title, body)
     @failed_examples ||= []
     return if @failed_examples.size <= 0
@@ -8,6 +12,7 @@ class NcFail < Nc
   end
 
   def example_failed(failure)
+    @failed_examples ||= []
     @failed_examples << failure
   end
 end

--- a/lib/nc_first_fail.rb
+++ b/lib/nc_first_fail.rb
@@ -1,7 +1,13 @@
 require 'nc'
 
 class NcFirstFail < Nc
+  if rspec_3?
+    RSpec::Core::Formatters.register self, :example_failed
+  end
+
   def example_failed(example)
+    # For rspec3
+    example = example.example if example.respond_to?(:example)
     @failed_examples ||= []
     if @failed_examples.size == 0
       name = File.basename(File.expand_path '.')
@@ -10,7 +16,8 @@ class NcFirstFail < Nc
     @failed_examples << example
   end
 
-  def dump_summary(duration, example_count, failure_count, pending_count)
+  def dump_summary(*args)
+    failure_count = self.class.rspec_3? ? args[0].failure_count : args[2]
     super if failure_count == 0
   end
 end

--- a/spec/nc_first_fail_spec.rb
+++ b/spec/nc_first_fail_spec.rb
@@ -7,24 +7,79 @@ describe NcFirstFail do
   let(:example2) { double 'example2' }
 
   let(:failure) { "\u26D4" }
+  let(:success) { "\u2705" }
   let(:exception) { 'exception' }
   let(:description) { 'description' }
 
-  it 'notifies the first failure only' do
-    allow(example).to receive(:metadata).and_return({:full_description => description})
-    allow(example).to receive(:exception).and_return(exception)
+  context 'for rspec 2' do
+    before do
+      allow(formatter.class).to receive(:rspec_3?).and_return(false)
+    end
 
-    expect(TerminalNotifier).to receive(:notify).with("#{description}\n#{exception}",
-      :title => "#{failure} #{current_dir}: Failure"
-    )
+    it 'notifies the first failure only' do
+      allow(example).to receive(:metadata).and_return({:full_description => description})
+      allow(example).to receive(:exception).and_return(exception)
 
-    formatter.example_failed(example)
-    formatter.example_failed(example2)
+      expect(TerminalNotifier).to receive(:notify).with("#{description}\n#{exception}",
+        :title => "#{failure} #{current_dir}: Failure"
+      ).once
+
+      formatter.example_failed(example)
+      formatter.example_failed(example2)
+    end
+
+    it "doesn't notify in the end if there has been any failures" do
+      expect(TerminalNotifier).to_not receive(:notify)
+
+      formatter.dump_summary(0.0001, 2, 1, 0)
+    end
+
+    it "notifies in the end if there is no failures" do
+      expect(TerminalNotifier).to receive(:notify).with(
+        "Finished in 0.0001 seconds\n2 examples, 0 failures",
+        :title => "#{success} #{current_dir}: Success"
+      )
+
+      formatter.dump_summary(0.0001, 2, 0, 0)
+    end
   end
 
-  it "doesn't notify in the end if there has been any failures" do
-    expect(TerminalNotifier).to_not receive(:notify)
+  context 'for rspec 3' do
+    let(:notification) {
+      Struct.new(:duration, :example_count, :failure_count, :pending_count).new(0.0001, 3, 1, 1)
+    }
+    let(:success_notification) {
+      Struct.new(:duration, :example_count, :failure_count, :pending_count).new(0.0001, 2, 0, 0)
+    }
+    before do
+      allow(formatter.class).to receive(:rspec_3?).and_return(true)
+    end
 
-    formatter.dump_summary(0.0001, 2, 1, 0)
+    it 'notifies the first failure only' do
+      allow(example).to receive(:metadata).and_return({:full_description => description})
+      allow(example).to receive(:exception).and_return(exception)
+
+      expect(TerminalNotifier).to receive(:notify).with("#{description}\n#{exception}",
+        :title => "#{failure} #{current_dir}: Failure"
+      ).once
+
+      formatter.example_failed(double(example: example))
+      formatter.example_failed(double(example: example2))
+    end
+
+    it "doesn't notify in the end if there has been any failures" do
+      expect(TerminalNotifier).to_not receive(:notify)
+
+      formatter.dump_summary(notification)
+    end
+
+    it "notifies in the end if there is no failures" do
+      expect(TerminalNotifier).to receive(:notify).with(
+        "Finished in 0.0001 seconds\n2 examples, 0 failures",
+        :title => "#{success} #{current_dir}: Success"
+      )
+
+      formatter.dump_summary(success_notification)
+    end
   end
 end

--- a/spec/nc_spec.rb
+++ b/spec/nc_spec.rb
@@ -8,30 +8,55 @@ describe Nc do
   let(:success) { "\u2705" }
   let(:failure) { "\u26D4" }
 
-  it 'returns the summary' do
-    expect(TerminalNotifier).to receive(:notify).with(
-      "Finished in 0.0001 seconds\n3 examples, 1 failure, 1 pending",
-      :title => "#{failure} #{current_dir}: 1 failed example"
-    )
 
-    formatter.dump_summary(0.0001, 3, 1, 1)
+  context 'for rspec 2' do
+    before do
+      allow(formatter.class).to receive(:rspec_3?).and_return(false)
+    end
+
+    it 'returns the summary' do
+      expect(TerminalNotifier).to receive(:notify).with(
+        "Finished in 0.0001 seconds\n3 examples, 1 failure, 1 pending",
+        :title => "#{failure} #{current_dir}: 1 failed example"
+      )
+
+      formatter.dump_summary(0.0001, 3, 1, 1)
+    end
+
+    it 'returns a failing notification' do
+      expect(TerminalNotifier).to receive(:notify).with(
+        "Finished in 0.0001 seconds\n1 example, 1 failure",
+        :title => "#{failure} #{current_dir}: 1 failed example"
+      )
+
+      formatter.dump_summary(0.0001, 1, 1, 0)
+    end
+
+    it 'returns a success notification' do
+      expect(TerminalNotifier).to receive(:notify).with(
+        "Finished in 0.0001 seconds\n1 example, 0 failures",
+        :title => "#{success} #{current_dir}: Success"
+      )
+
+      formatter.dump_summary(0.0001, 1, 0, 0)
+    end
   end
 
-  it 'returns a failing notification' do
-    expect(TerminalNotifier).to receive(:notify).with(
-      "Finished in 0.0001 seconds\n1 example, 1 failure",
-      :title => "#{failure} #{current_dir}: 1 failed example"
-    )
+  context 'for rspec 3' do
+    let(:notification) {
+      Struct.new(:duration, :example_count, :failure_count, :pending_count).new(0.0001, 3, 1, 1)
+    }
+    before do
+      allow(formatter.class).to receive(:rspec_3?).and_return(true)
+    end
 
-    formatter.dump_summary(0.0001, 1, 1, 0)
-  end
+    it "shows the summary" do
+      expect(TerminalNotifier).to receive(:notify).with(
+        "Finished in 0.0001 seconds\n3 examples, 1 failure, 1 pending",
+        :title => "#{failure} #{current_dir}: 1 failed example"
+      )
 
-  it 'returns a success notification' do
-    expect(TerminalNotifier).to receive(:notify).with(
-      "Finished in 0.0001 seconds\n1 example, 0 failures",
-      :title => "#{success} #{current_dir}: Success"
-    )
-
-    formatter.dump_summary(0.0001, 1, 0, 0)
+      formatter.dump_summary(notification)
+    end
   end
 end


### PR DESCRIPTION
Fixed the warning "The Nc formatter uses the deprecated formatter interface not supported directly by RSpec 3.  To continue to use this formatter you must install the `rspec-legacy_formatters` gem, which provides support for legacy formatters or upgrade the formatter to a compatible version.".

refer to: http://myronmars.to/n/dev-blog/2014/02/rspec-2-99-and-3-0-beta-2-have-been-released#rspeccore_300beta2 and http://rubydoc.info/gems/rspec-core/RSpec/Core/Formatters
