### PR TITLE
No output to stdout at all

### DIFF
--- a/lib/nc.rb
+++ b/lib/nc.rb
@@ -40,6 +40,8 @@ class Nc < RSpec::Core::Formatters::BaseTextFormatter
   def dump_pending(*args); end
   def dump_failures(*args); end
   def message(message); end
+  def seed(notification); end
+  def close(notification); end
 
   private
 

--- a/spec/nc_spec.rb
+++ b/spec/nc_spec.rb
@@ -58,4 +58,12 @@ describe Nc do
       formatter.dump_summary(notification)
     end
   end
+
+  %w{dump_pending dump_failures message seed close}.each do |event|
+    it "produces no output for the #{event} notification" do
+      $stdout = StringIO.new
+      formatter.send(event, double('notification'))
+      expect($stdout.string).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Override seed and close notifications to avoid them falling back to the BaseTextFormatter and outputting to stdout.

rake output shows current tests pass for RSpec 2.9 and 3.  I haven't added new tests because I wasn't sure how to test for the absence of output, but I have tested manually under RSpec 3.3.2.