### PR TITLE
Prevent unnecessary require when the constant is already defined

### DIFF
--- a/lib/nc.rb
+++ b/lib/nc.rb
@@ -51,7 +51,7 @@ class Nc < RSpec::Core::Formatters::BaseTextFormatter
     if respond_to? :format_duration
       format_duration duration
     else
-      require 'rspec/core/formatters/helpers'
+      require 'rspec/core/formatters/helpers' unless Object.const_defined?('RSpec')
       RSpec::Core::Formatters::Helpers.format_duration duration
     end
   end


### PR DESCRIPTION
About issue #17

I was looking at the `lib/nc.rb` file, trying to find the reason for this warnings, when I faced this:
```ruby
else
  require 'rspec/core/formatters/helpers'
  RSpec::Core::Formatters::Helpers.format_duration duration
end
```
https://github.com/twe4ked/rspec-nc/blob/master/lib/nc.rb#L54

@twe4ked can you explain why you need to require the `Formatters::Helpers` ?

My suggestion to avoid the warnings is to check if the constant `RSpec::Core::Formatters::Helpers` is already defined, before requiring it again. Though I believe we could just remove the `require`, because it is already being required by rspec autoload. 