### PR TITLE
Delete all but the latest notification

### DIFF
--- a/lib/nc.rb
+++ b/lib/nc.rb
@@ -24,6 +24,6 @@ class Nc < RSpec::Core::Formatters::BaseFormatter
   end
 
   def notify(title, body)
-    TerminalNotifier.notify body, title: title
+    TerminalNotifier.notify body, title: title, group: directory_name, remove: directory_name
   end
 end


### PR DESCRIPTION
At the moment running tests a lot results in very full Notification Centre. This deletes all but the most recent test result.

Merge or discard at will. :-)